### PR TITLE
chore: add GitHub Actions workflow to update major version floating t…

### DIFF
--- a/.github/workflows/update-floating-tag.yml
+++ b/.github/workflows/update-floating-tag.yml
@@ -1,0 +1,29 @@
+name: Update Major Version Floating Tag
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  update-floating-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract major version and move floating tag
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+
+          # Get the correct commit for the tag
+          COMMIT_SHA=$(git rev-list -n 1 $GITHUB_REF)
+          
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          echo "Moving floating tag ${MAJOR} to commit ${COMMIT_SHA}"
+          git tag -f "${MAJOR}" "${COMMIT_SHA}"
+          git push -f origin "${MAJOR}"

--- a/.github/workflows/update-floating-tag.yml
+++ b/.github/workflows/update-floating-tag.yml
@@ -9,17 +9,17 @@ jobs:
   update-floating-tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Extract major version and move floating tag
         run: |
-          VERSION=${GITHUB_REF#refs/tags/}
-          MAJOR=${VERSION%%.*}
+          readonly VERSION=${GITHUB_REF#refs/tags/}
+          readonly MAJOR=${VERSION%%.*}
 
           # Get the correct commit for the tag
-          COMMIT_SHA=$(git rev-list -n 1 $GITHUB_REF)
+          readonly COMMIT_SHA=$(git rev-list -n 1 $GITHUB_REF)
           
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'


### PR DESCRIPTION

* **Tag Manipulation:** The core of the workflow is a `run` step that uses shell commands to:
    * **Extract the version:** It gets the new tag (e.g., `v1.2.3`) from the `GITHUB_REF` environment variable and extracts just the major version (`v1`).
    * **Get commit SHA:** It finds the specific commit hash that the new tag points to.
    * **Configure Git:** It sets the user name and email for the Git commit to `github-actions[bot]`, clearly indicating an automated change.
    * **Update the tag:** It uses `git tag -f` to forcibly move the major version tag (e.g., `v1`) to the commit hash of the new tag.
    * **Push the tag:** It uses `git push -f` to force-push the updated major version tag to the remote repository, making it available for other users to reference.