### PR TITLE
feat: dry_run input + apply it to the self-test job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ INPUT_GITHUB_TOKEN=github_personal_token
 # repo and you want to scope a quick run to one file.
 # INPUT_PATHS=README.md
 
+# Dry-run mode. When "true", the action does the full analysis but skips
+# every GitHub-side write (PR comment, inline reviews, commit status, job
+# summary). The rendered markdown is logged so you can preview the result.
+# INPUT_DRY_RUN=true
+
 GITHUB_REPOSITORY=markupai/content-guardian-action
 GITHUB_EVENT_NAME=push
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,15 @@ jobs:
       - name: Test Local Action
         uses: ./
         with:
+          # `dry_run: true` runs the full analysis (config, target resolve,
+          # /run, polling) and emits `outputs.results` JSON to the run log,
+          # but skips every GitHub-side write — no PR comments, no inline
+          # reviews, no commit status. Keeps this job pollution-free while
+          # still exercising the live wire path.
+          # `paths: README.md` and `add_review_comments: false` are redundant
+          # under dry-run but kept as belt-and-suspenders.
+          dry_run: "true"
+          add_review_comments: "false"
           paths: README.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Either inputs or env vars work; inputs take precedence when both are set.
 | `add_commit_status`   | Add commit status updates for push events                                                                                                                          | No       | `true`      |
 | `add_review_comments` | Add PR review comments for issues                                                                                                                                  | No       | `true`      |
 | `strict_mode`         | Fail the action if any file fails analysis                                                                                                                         | No       | `false`     |
+| `dry_run`             | Run the full analysis but skip every GitHub-side write (PR comments, inline reviews, commit status, job summary). Useful for self-testing without polluting a PR.  | No       | `false`     |
 
 ## Outputs
 
@@ -280,6 +281,31 @@ Behaviour:
 Typical use: drop a `paths: README.md` on the action's own self-test
 workflow so the build matrix exercises the wire path on every PR without
 spamming a 20-file analysis result.
+
+## Dry-run mode
+
+`dry_run: true` runs the full analysis pipeline (config fetch, target
+resolution, `/run`, polling, response parsing) and still populates
+`outputs.results` with the full per-file JSON, but **skips every write to
+GitHub**: no PR comment, no inline review comments, no commit status, no
+job summary. The rendered markdown that _would_ have been posted is logged
+to the run output so you can preview it.
+
+```yaml
+- uses: markupai/content-guardian-action@v2
+  with:
+    markup_ai_api_key: ${{ secrets.MARKUP_AI_API_KEY }}
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    dry_run: "true"
+```
+
+Typical uses:
+
+- Self-testing the action's CI on its own PRs without polluting the PR
+  with 30+ inline comments — the analysis still runs against the live
+  Markup AI API so the wire path is exercised.
+- Letting downstream steps key on `outputs.results` JSON without showing
+  anything to PR reviewers.
 
 ## Strict mode
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,14 @@ inputs:
     description: Fail the action if any file fails analysis (default false).
     required: false
     default: "false"
+  dry_run:
+    description: "When true, the action performs the full analysis and emits
+      `outputs.results` JSON as usual, but skips every write to GitHub: no
+      PR comments, no inline reviews, no commit status, no job summary. The
+      rendered markdown is logged so the result is observable. Useful for
+      self-testing the action without polluting a PR."
+    required: false
+    default: "false"
 
 outputs:
   event-type:

--- a/dist/index.js
+++ b/dist/index.js
@@ -87663,6 +87663,7 @@ const INPUT_NAMES = {
     ADD_REVIEW_COMMENTS: "add_review_comments",
     STRICT_MODE: "strict_mode",
     PATHS: "paths",
+    DRY_RUN: "dry_run",
 };
 const ENV_VARS = {
     MARKUP_AI_API_KEY: "MARKUP_AI_API_KEY",
@@ -87700,6 +87701,7 @@ function getActionConfig() {
     const strictMode = getBooleanInput(INPUT_NAMES.STRICT_MODE, false);
     const addCommitStatus = getBooleanInput(INPUT_NAMES.ADD_COMMIT_STATUS, true);
     const addReviewComments = getBooleanInput(INPUT_NAMES.ADD_REVIEW_COMMENTS, true);
+    const dryRun = getBooleanInput(INPUT_NAMES.DRY_RUN, false);
     return {
         apiToken,
         githubToken,
@@ -87708,6 +87710,7 @@ function getActionConfig() {
         addCommitStatus,
         addReviewComments,
         strictMode,
+        dryRun,
     };
 }
 /**
@@ -87767,6 +87770,7 @@ function logConfiguration(config) {
     info(`  Commit Status: ${config.addCommitStatus ? "enabled" : "disabled"}`);
     info(`  Review Comments: ${config.addReviewComments ? "enabled" : "disabled"}`);
     info(`  Strict Mode: ${config.strictMode ? "on" : "off"}`);
+    info(`  Dry Run: ${config.dryRun ? "on (no GitHub writes)" : "off"}`);
 }
 
 /**
@@ -89311,9 +89315,36 @@ async function handlePullRequestEvent(octokit, owner, repo, results, options, ad
         error(`Failed to create PR comment: ${String(error$1)}`);
     }
 }
+/**
+ * Dry-run short-circuit. Renders the markdown that would have been posted
+ * (summary comment for PRs / job summary for manual+scheduled) and logs it
+ * to the run output so reviewers can inspect the would-be result without
+ * any GitHub-side writes happening.
+ */
+function logDryRun(eventInfo, results, options) {
+    displaySectionHeader("🧪 Dry Run");
+    info("Dry-run mode is enabled — skipping commit status updates, PR comments, inline reviews, and job summary writes.");
+    const { owner, repo } = context.repo;
+    const context$1 = {
+        owner,
+        repo,
+        ref: context.ref,
+        baseUrl: new URL(context.serverUrl),
+        runId: context.runId,
+    };
+    const header = `## 🔍 Markup AI Analysis Results (dry run)
+
+This is the markdown that would have been posted for **${eventInfo.eventType}** if dry_run were off.`;
+    const markdown = generateAnalysisContent(results, options, header, eventInfo.eventType, context$1);
+    info(`Rendered preview:\n${markdown}`);
+}
 async function handlePostAnalysisActions(eventInfo, results, config, options) {
     if (results.length === 0) {
         info("No results to process for post-analysis actions.");
+        return;
+    }
+    if (config.dryRun) {
+        logDryRun(eventInfo, results, options);
         return;
     }
     const octokit = createGitHubClient(config.githubToken);

--- a/src/config/action-config.ts
+++ b/src/config/action-config.ts
@@ -16,6 +16,7 @@ export function getActionConfig(): ActionConfig {
   const strictMode = getBooleanInput(INPUT_NAMES.STRICT_MODE, false);
   const addCommitStatus = getBooleanInput(INPUT_NAMES.ADD_COMMIT_STATUS, true);
   const addReviewComments = getBooleanInput(INPUT_NAMES.ADD_REVIEW_COMMENTS, true);
+  const dryRun = getBooleanInput(INPUT_NAMES.DRY_RUN, false);
 
   return {
     apiToken,
@@ -25,6 +26,7 @@ export function getActionConfig(): ActionConfig {
     addCommitStatus,
     addReviewComments,
     strictMode,
+    dryRun,
   };
 }
 
@@ -91,4 +93,5 @@ export function logConfiguration(config: ActionConfig): void {
   core.info(`  Commit Status: ${config.addCommitStatus ? "enabled" : "disabled"}`);
   core.info(`  Review Comments: ${config.addReviewComments ? "enabled" : "disabled"}`);
   core.info(`  Strict Mode: ${config.strictMode ? "on" : "off"}`);
+  core.info(`  Dry Run: ${config.dryRun ? "on (no GitHub writes)" : "off"}`);
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -41,6 +41,7 @@ export const INPUT_NAMES = {
   ADD_REVIEW_COMMENTS: "add_review_comments",
   STRICT_MODE: "strict_mode",
   PATHS: "paths",
+  DRY_RUN: "dry_run",
 } as const;
 
 export const ENV_VARS = {

--- a/src/services/post-analysis-service.ts
+++ b/src/services/post-analysis-service.ts
@@ -14,7 +14,7 @@ import {
 } from "./pr-comment-service.js";
 import { createGitHubClient, updateCommitStatus } from "./github-service.js";
 import { createJobSummary } from "./job-summary-service.js";
-import { RepositoryContext } from "../utils/markdown-utils.js";
+import { generateAnalysisContent, RepositoryContext } from "../utils/markdown-utils.js";
 import { displaySectionHeader } from "../utils/display-utils.js";
 
 async function handlePushEvent(
@@ -101,14 +101,56 @@ async function handlePullRequestEvent(
   }
 }
 
+/**
+ * Dry-run short-circuit. Renders the markdown that would have been posted
+ * (summary comment for PRs / job summary for manual+scheduled) and logs it
+ * to the run output so reviewers can inspect the would-be result without
+ * any GitHub-side writes happening.
+ */
+function logDryRun(
+  eventInfo: EventInfo,
+  results: AnalysisResult[],
+  options: AnalysisOptions,
+): void {
+  displaySectionHeader("🧪 Dry Run");
+  core.info(
+    "Dry-run mode is enabled — skipping commit status updates, PR comments, inline reviews, and job summary writes.",
+  );
+  const { owner, repo } = github.context.repo;
+  const context: RepositoryContext = {
+    owner,
+    repo,
+    ref: github.context.ref,
+    baseUrl: new URL(github.context.serverUrl),
+    runId: github.context.runId,
+  };
+  const header = `## 🔍 Markup AI Analysis Results (dry run)
+
+This is the markdown that would have been posted for **${eventInfo.eventType}** if dry_run were off.`;
+  const markdown = generateAnalysisContent(results, options, header, eventInfo.eventType, context);
+  core.info(`Rendered preview:\n${markdown}`);
+}
+
+export interface PostAnalysisConfig {
+  githubToken: string;
+  addCommitStatus: boolean;
+  addReviewComments: boolean;
+  dryRun: boolean;
+}
+
 export async function handlePostAnalysisActions(
   eventInfo: EventInfo,
   results: AnalysisResult[],
-  config: { githubToken: string; addCommitStatus: boolean; addReviewComments: boolean },
+  config: PostAnalysisConfig,
   options: AnalysisOptions,
 ): Promise<void> {
   if (results.length === 0) {
     core.info("No results to process for post-analysis actions.");
+    return;
+  }
+
+  if (config.dryRun) {
+    logDryRun(eventInfo, results, options);
     return;
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -156,6 +156,13 @@ export interface ActionConfig {
   addCommitStatus: boolean;
   addReviewComments: boolean;
   strictMode: boolean;
+  /** When true, the action performs the full analysis (config fetch,
+   * target resolution, /run, polling) and produces the same outputs JSON,
+   * but skips every write to GitHub: no PR comments, no inline reviews,
+   * no commit status, no job summary. The rendered markdown is still
+   * emitted to the run log so the result is observable. Useful for
+   * self-testing the action without polluting a PR. */
+  dryRun: boolean;
 }
 
 export interface AnalysisOptions {

--- a/test/config/action-config.test.ts
+++ b/test/config/action-config.test.ts
@@ -29,6 +29,7 @@ function baseConfig(overrides: Partial<ActionConfig> = {}): ActionConfig {
     addCommitStatus: true,
     addReviewComments: true,
     strictMode: false,
+    dryRun: false,
     ...overrides,
   };
 }
@@ -88,6 +89,7 @@ describe("getActionConfig", () => {
       addCommitStatus: true,
       addReviewComments: true,
       strictMode: false,
+      dryRun: false,
     });
   });
 

--- a/test/services/post-analysis-service.test.ts
+++ b/test/services/post-analysis-service.test.ts
@@ -46,7 +46,12 @@ import { EVENT_TYPES } from "../../src/constants/index.js";
 const { handlePostAnalysisActions } = await import("../../src/services/post-analysis-service.js");
 
 const mockOctokit = { rest: {} };
-const config = { githubToken: "tok", addCommitStatus: true, addReviewComments: true };
+const config = {
+  githubToken: "tok",
+  addCommitStatus: true,
+  addReviewComments: true,
+  dryRun: false,
+};
 const options = buildAnalysisOptions();
 const results = [buildAnalysisResult()];
 
@@ -163,5 +168,59 @@ describe("handlePostAnalysisActions", () => {
     expect(mockUpdateCommitStatus).not.toHaveBeenCalled();
     expect(mockCreateJobSummary).not.toHaveBeenCalled();
     expect(mockCreateOrUpdatePRComment).not.toHaveBeenCalled();
+  });
+
+  describe("dryRun: true", () => {
+    const dryConfig = { ...config, dryRun: true };
+
+    it("skips commit status on push events", async () => {
+      mockIsPullRequestEvent.mockReturnValue(false);
+      await handlePostAnalysisActions(
+        { eventType: EVENT_TYPES.PUSH, filesCount: 1, description: "" },
+        results,
+        dryConfig,
+        options,
+      );
+      expect(mockCreateGitHubClient).not.toHaveBeenCalled();
+      expect(mockUpdateCommitStatus).not.toHaveBeenCalled();
+    });
+
+    it("skips PR comment + inline reviews on pull_request events", async () => {
+      mockIsPullRequestEvent.mockReturnValue(true);
+      mockGetPRNumber.mockReturnValue(42);
+      await handlePostAnalysisActions(
+        { eventType: EVENT_TYPES.PULL_REQUEST, filesCount: 1, description: "" },
+        results,
+        dryConfig,
+        options,
+      );
+      expect(mockCreateOrUpdatePRComment).not.toHaveBeenCalled();
+      expect(mockCreatePRReviewComments).not.toHaveBeenCalled();
+    });
+
+    it("skips the job summary on workflow_dispatch/schedule events", async () => {
+      await handlePostAnalysisActions(
+        { eventType: EVENT_TYPES.WORKFLOW_DISPATCH, filesCount: 1, description: "" },
+        results,
+        dryConfig,
+        options,
+      );
+      expect(mockCreateJobSummary).not.toHaveBeenCalled();
+    });
+
+    it("still emits a dry-run section header so the run is observable", async () => {
+      const coreModule = await import("@actions/core");
+      await handlePostAnalysisActions(
+        { eventType: EVENT_TYPES.PULL_REQUEST, filesCount: 1, description: "" },
+        results,
+        dryConfig,
+        options,
+      );
+      const messages = (coreModule.info as unknown as { mock: { calls: unknown[][] } }).mock.calls
+        .map((args) => args[0] as string)
+        .filter((msg): msg is string => typeof msg === "string");
+      expect(messages.some((m) => m.includes("Dry Run"))).toBe(true);
+      expect(messages.some((m) => m.includes("Dry-run mode"))).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds a new \`dry_run\` input to the action, and switches \`build.yml\`'s \`github-action-test\` job to use it. Solves the recurring "test action pollutes the PR" problem we hit on PR #335 — that job was producing 30–40 inline review comments per PR even after we narrowed \`paths\` to README.md, and developers had to resolve them all before merging.

## What \`dry_run: true\` does

- Runs the full pipeline: config fetch, target resolution, \`/run\`, polling, response parsing, issue mapping.
- Still emits \`outputs.results\` JSON so downstream steps can act on it.
- **Skips every GitHub-side write**: no PR summary comment, no inline review comments, no commit status, no job summary.
- Logs the rendered markdown via \`core.info\` so the run is observable.

## Why this and not just remove the test job

We considered five alternatives in the Slack thread (live + auto-delete, scheduled run against a separate repo, workflow_dispatch-only, action.yml validator only, integration tests only). Dry-run wins because:

- The job still runs on every PR — bugs in dist/, action.yml, or the wire path get caught before merge.
- Zero pollution: no developer ever has to resolve a comment from the self-test.
- Reusable beyond CI: any consumer who wants the JSON output without posting comments can flip this same input.

## Test plan

- [x] 265 unit tests pass (4 new for the dry-run path).
- [x] Lint, format, type-check clean.
- [x] dist regenerated.
- [ ] Verify \`github-action-test\` job runs to success on this PR with **no comments posted** by the action itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)