### PR TITLE
feat: rename `target` input to `style_guide`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,13 +12,13 @@ ACTIONS_STEP_DEBUG=true
 INPUT_MARKUP_AI_API_KEY=your_markup_ai_key
 INPUT_GITHUB_TOKEN=github_personal_token
 
-# Style guide / target. Optional — omit to use the organization's default
-# target (the one flagged `is_default: true` in /style-agent/targets). To
-# pin a specific target, set this to either its ID or display name; look
-# them up with:
+# Style guide. Optional — omit to use the organization's default style guide
+# (the one flagged `is_default: true` in /style-agent/targets). To pin a
+# specific style guide, set this to either its ID or display name; look them
+# up with:
 #   curl -H "Authorization: Bearer $INPUT_MARKUP_AI_API_KEY" \
 #     https://api.markup.ai/style-agent/targets
-# INPUT_TARGET=
+# INPUT_STYLE_GUIDE=
 
 # Optional path whitelist. Comma-separated repo-relative paths; when set,
 # only matching files are analyzed. Useful when running locally against a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A GitHub Action (`markupai/content-guardian-action`) that analyzes content files (DITA, HTML, Markdown, plain text, XML) on commits/PRs against Markup AI's style agent. The Action's behavior is event-driven — it adapts what it reads, what it reports, and how it surfaces results based on the GitHub event type (`push`, `pull_request`, `workflow_dispatch`, `schedule`).
 
-**v2 is a direct-API rewrite.** The action no longer depends on `@markupai/toolkit`; it calls `https://api.markup.ai/` directly via `fetch`, runs the style agent's `/run` endpoint per file, and polls workflow status until terminal. Inputs were collapsed: v1's `dialect` + `tone` + `style-guide` became a single required `target` input that accepts a target ID or display name.
+**v2 is a direct-API rewrite.** The action no longer depends on `@markupai/toolkit`; it calls `https://api.markup.ai/` directly via `fetch`, runs the style agent's `/run` endpoint per file, and polls workflow status until terminal. Inputs were collapsed: v1's `dialect` + `tone` + `style-guide` became a single `style_guide` input that accepts a style guide (target) ID or display name. `style_guide` is the public input name (marketing terminology); internally it maps to the style agent's `target`/`target_id`.
 
 Runtime: Node 24 (see `.node-version`, `engines.node`). The published action runs `dist/index.js` (see `action.yml`).
 
@@ -45,8 +45,8 @@ Entry chain: `dist/index.js` (rollup output) ← `src/index.ts` (calls `run()`) 
 
 The runner is a linear pipeline:
 
-1. **Config** (`src/config/action-config.ts`) reads inputs/env via `@actions/core`, validates, and produces an `ActionConfig` with one required style input: `target`. Inputs fall back to env vars (e.g. `markup_ai_api_key` → `MARKUP_AI_API_KEY`).
-2. **Bootstrap** — call `GET /style-agent/config` to read `style_agent_numeric_scoring` and assert style agent is enabled, then call `GET /style-agent/targets` and resolve the user's `target` input (by id or case-insensitive display_name) via `services/target-resolver.ts`. The resulting `AnalysisOptions` carries `{ targetId, targetDisplayName, numericScoringEnabled }`.
+1. **Config** (`src/config/action-config.ts`) reads inputs/env via `@actions/core`, validates, and produces an `ActionConfig` with one optional style input: `style_guide` (carried internally on `config.target`). Inputs fall back to env vars (e.g. `markup_ai_api_key` → `MARKUP_AI_API_KEY`).
+2. **Bootstrap** — call `GET /style-agent/config` to read `style_agent_numeric_scoring` and assert style agent is enabled, then call `GET /style-agent/targets` and resolve the user's `style_guide` input (carried on `config.target`, by id or case-insensitive display_name) via `services/target-resolver.ts`. The resulting `AnalysisOptions` carries `{ targetId, targetDisplayName, numericScoringEnabled }`.
 3. **File discovery** (`src/strategies/file-discovery-strategies.ts`) — strategy pattern keyed on `github.context.eventName`:
    - `push` → files touched in that commit (excluding deletions)
    - `pull_request` → files changed in the PR
@@ -87,7 +87,7 @@ Thin fetch-based wrapper. Single `request<T>()` helper sets `Authorization: Bear
 
 ## Local development
 
-`npm run local-action` uses `@github/local-action` to run `src/main.ts` against `.env` (see `.env.example`). Env vars follow the GitHub Actions `INPUT_<NAME>` convention — and the runner is strict about it, so `INPUT_TARGET` keeps the underscore (the input name is `target`, not `style-guide` anymore). `.github/event.json` is a sample event payload for local PR runs.
+`npm run local-action` uses `@github/local-action` to run `src/main.ts` against `.env` (see `.env.example`). Env vars follow the GitHub Actions `INPUT_<NAME>` convention — and the runner is strict about it, so `INPUT_STYLE_GUIDE` keeps the underscore (the public input name is `style_guide`, mapped internally to the agent's `target`). `.github/event.json` is a sample event payload for local PR runs.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ manual, and scheduled events.
 
 - **Direct agentic API** — no longer uses `@markupai/toolkit`; talks to
   `https://api.markup.ai` directly.
-- **Single optional `target` input** — replaces v1's `dialect` / `tone` /
-  `style-guide` combo. Omit it to use the organization's default target
-  (the one flagged `is_default: true`); pass a target ID or display name
+- **Single optional `style_guide` input** — replaces v1's `dialect` / `tone` /
+  `style-guide` combo. Omit it to use the organization's default style guide
+  (the one flagged `is_default: true`); pass a style guide ID or display name
   to pin a specific one. Look them up at
   [console.markup.ai](https://console.markup.ai).
 - **Risk-based scoring is the primary view, always.** Every PR comment, commit
@@ -27,9 +27,9 @@ manual, and scheduled events.
   on the next run (see [Comment lifecycle](#pull-request-on-pull_request)).
 
 Migrating from v1: drop `dialect`, `tone`, and `style-guide`. The new
-`target` input is optional — set your org's default target in
+`style_guide` input is optional — set your org's default style guide in
 [console.markup.ai](https://console.markup.ai) and you don't need to pass
-anything; otherwise pass `target: <id or display name>`.
+anything; otherwise pass `style_guide: <id or display name>`.
 
 ## Features
 
@@ -85,7 +85,7 @@ jobs:
         with:
           markup_ai_api_key: ${{ secrets.MARKUP_AI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # `target` omitted → uses the organization's default target.
+          # `style_guide` omitted → uses the organization's default style guide.
 ```
 
 ### Advanced configuration
@@ -108,7 +108,7 @@ jobs:
         with:
           markup_ai_api_key: ${{ secrets.MARKUP_AI_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          target: ${{ secrets.MARKUP_AI_TARGET_ID }} # optional — accepts ID or display name; omit to use the org's default
+          style_guide: ${{ secrets.MARKUP_AI_STYLE_GUIDE_ID }} # optional — accepts ID or display name; omit to use the org's default
           add_commit_status: "true"
           add_review_comments: "true"
           strict_mode: "false"
@@ -137,7 +137,7 @@ Either inputs or env vars work; inputs take precedence when both are set.
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ----------- |
 | `markup_ai_api_key`   | Markup AI API key (or `MARKUP_AI_API_KEY` env var)                                                                                                                 | Yes      | -           |
 | `github_token`        | GitHub token (or `GITHUB_TOKEN` env var)                                                                                                                           | Yes      | -           |
-| `target`              | Style guide / target — target ID or display_name (case-insensitive). Omit to use the org's default target.                                                         | No       | org default |
+| `style_guide`         | Style guide — style guide (target) ID or display_name (case-insensitive). Omit to use the org's default style guide.                                               | No       | org default |
 | `paths`               | Comma- or newline-separated repo-relative paths. When set, intersects with the discovered files; only matches are analyzed. Empty = analyze everything discovered. | No       | (none)      |
 | `add_commit_status`   | Add commit status updates for push events                                                                                                                          | No       | `true`      |
 | `add_review_comments` | Add PR review comments for issues                                                                                                                                  | No       | `true`      |
@@ -229,16 +229,16 @@ The full per-file structure (issues, scores when available, workflow IDs) is
 always available in the `outputs.results` JSON for downstream consumers,
 regardless of which view is rendered.
 
-## Finding your `target` value
+## Finding your `style_guide` value
 
-The `target` input is **optional**. When omitted, the action uses the
-organization's default target — the one flagged `is_default: true` in
+The `style_guide` input is **optional**. When omitted, the action uses the
+organization's default style guide — the one flagged `is_default: true` in
 `/style-agent/targets`. Configure that default in
 [console.markup.ai](https://console.markup.ai); most teams only need to set
-it once and never pass `target` in the workflow.
+it once and never pass `style_guide` in the workflow.
 
-To pin a specific non-default target, look up the available targets and pass
-either the `id` or the `display_name`:
+To pin a specific non-default style guide, look up the available style guides
+and pass either the `id` or the `display_name`:
 
 ```bash
 curl -H "Authorization: Bearer $MARKUP_AI_API_KEY" \
@@ -333,7 +333,7 @@ npm install
 
 ```bash
 cp .env.example .env
-# edit .env: set INPUT_MARKUP_AI_API_KEY, INPUT_GITHUB_TOKEN, INPUT_TARGET
+# edit .env: set INPUT_MARKUP_AI_API_KEY, INPUT_GITHUB_TOKEN, INPUT_STYLE_GUIDE
 npm run local-action
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,12 @@ inputs:
     description: Markup AI API key (can also be provided via the MARKUP_AI_API_KEY
       environment variable).
     required: true
-  target:
-    description: "Style guide to analyze against. Accepts either a target ID
-      or the display name of an enabled target (case-insensitive). When
-      omitted, the action uses the organization's default target (the one
-      flagged `is_default: true` in /style-agent/targets)."
+  style_guide:
+    description: "Style guide to analyze against. Accepts either a style guide
+      (target) ID or the display name of an enabled style guide
+      (case-insensitive). When omitted, the action uses the organization's
+      default style guide (the one flagged `is_default: true` in
+      /style-agent/targets)."
     required: false
   paths:
     description: "Optional whitelist of repo-relative paths to analyze. When

--- a/dist/index.js
+++ b/dist/index.js
@@ -87657,7 +87657,9 @@ const MAX_CONCURRENT_FILES = 3;
 const MAX_INLINE_REVIEW_COMMENTS = 50;
 const INPUT_NAMES = {
     MARKUP_AI_API_KEY: "markup_ai_api_key",
-    TARGET: "target",
+    // Public input name. Internally mapped to the style agent's `target` (see
+    // action-config.ts and target-resolver.ts) — the API still expects a target.
+    STYLE_GUIDE: "style_guide",
     GITHUB_TOKEN: "github_token",
     ADD_COMMIT_STATUS: "add_commit_status",
     ADD_REVIEW_COMMENTS: "add_review_comments",
@@ -87694,9 +87696,12 @@ const ERROR_MESSAGES = {
 function getActionConfig() {
     const apiToken = getRequiredInput(INPUT_NAMES.MARKUP_AI_API_KEY, ENV_VARS.MARKUP_AI_API_KEY);
     const githubToken = getRequiredInput(INPUT_NAMES.GITHUB_TOKEN, ENV_VARS.GITHUB_TOKEN);
-    // `target` is optional: when omitted, the action falls back to the org's
-    // default target (the one flagged `is_default: true` in /style-agent/targets).
-    const target = getOptionalInput(INPUT_NAMES.TARGET, "TARGET");
+    // `style_guide` is the public input name (matches our marketing terminology).
+    // Internally it maps to the style agent's `target` — the API expects a
+    // `target_id`, so we carry the value on `config.target` from here on.
+    // Optional: when omitted, the action falls back to the org's default target
+    // (the one flagged `is_default: true` in /style-agent/targets).
+    const target = getOptionalInput(INPUT_NAMES.STYLE_GUIDE, "STYLE_GUIDE");
     const paths = parsePaths(getOptionalInput(INPUT_NAMES.PATHS, "PATHS"));
     const strictMode = getBooleanInput(INPUT_NAMES.STRICT_MODE, false);
     const addCommitStatus = getBooleanInput(INPUT_NAMES.ADD_COMMIT_STATUS, true);

--- a/src/config/action-config.ts
+++ b/src/config/action-config.ts
@@ -9,9 +9,12 @@ import { INPUT_NAMES, ENV_VARS } from "../constants/index.js";
 export function getActionConfig(): ActionConfig {
   const apiToken = getRequiredInput(INPUT_NAMES.MARKUP_AI_API_KEY, ENV_VARS.MARKUP_AI_API_KEY);
   const githubToken = getRequiredInput(INPUT_NAMES.GITHUB_TOKEN, ENV_VARS.GITHUB_TOKEN);
-  // `target` is optional: when omitted, the action falls back to the org's
-  // default target (the one flagged `is_default: true` in /style-agent/targets).
-  const target = getOptionalInput(INPUT_NAMES.TARGET, "TARGET");
+  // `style_guide` is the public input name (matches our marketing terminology).
+  // Internally it maps to the style agent's `target` — the API expects a
+  // `target_id`, so we carry the value on `config.target` from here on.
+  // Optional: when omitted, the action falls back to the org's default target
+  // (the one flagged `is_default: true` in /style-agent/targets).
+  const target = getOptionalInput(INPUT_NAMES.STYLE_GUIDE, "STYLE_GUIDE");
   const paths = parsePaths(getOptionalInput(INPUT_NAMES.PATHS, "PATHS"));
   const strictMode = getBooleanInput(INPUT_NAMES.STRICT_MODE, false);
   const addCommitStatus = getBooleanInput(INPUT_NAMES.ADD_COMMIT_STATUS, true);

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -35,7 +35,9 @@ export const MAX_INLINE_REVIEW_COMMENTS = 50;
 
 export const INPUT_NAMES = {
   MARKUP_AI_API_KEY: "markup_ai_api_key",
-  TARGET: "target",
+  // Public input name. Internally mapped to the style agent's `target` (see
+  // action-config.ts and target-resolver.ts) — the API still expects a target.
+  STYLE_GUIDE: "style_guide",
   GITHUB_TOKEN: "github_token",
   ADD_COMMIT_STATUS: "add_commit_status",
   ADD_REVIEW_COMMENTS: "add_review_comments",

--- a/test/action-runner.test.ts
+++ b/test/action-runner.test.ts
@@ -99,7 +99,7 @@ function defaultInputMock(overrides: Record<string, string> = {}) {
         return "key";
       case "github_token":
         return "tok";
-      case "target":
+      case "style_guide":
         return "Marketing Voice";
       case "strict_mode":
         return "true";

--- a/test/config/action-config.test.ts
+++ b/test/config/action-config.test.ts
@@ -11,13 +11,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.MARKUP_AI_API_KEY;
   delete process.env.GITHUB_TOKEN;
-  delete process.env.TARGET;
+  delete process.env.STYLE_GUIDE;
 });
 
 afterEach(() => {
   delete process.env.MARKUP_AI_API_KEY;
   delete process.env.GITHUB_TOKEN;
-  delete process.env.TARGET;
+  delete process.env.STYLE_GUIDE;
 });
 
 function baseConfig(overrides: Partial<ActionConfig> = {}): ActionConfig {
@@ -79,7 +79,7 @@ describe("getActionConfig", () => {
     inputs({
       markup_ai_api_key: "tok",
       github_token: "gh",
-      target: "Marketing Voice",
+      style_guide: "Marketing Voice",
     });
     expect(getActionConfig()).toEqual({
       apiToken: "tok",
@@ -120,7 +120,7 @@ describe("getActionConfig", () => {
     core.getInput.mockReturnValue("");
     process.env.MARKUP_AI_API_KEY = "env-tok";
     process.env.GITHUB_TOKEN = "env-gh";
-    process.env.TARGET = "Brand Voice";
+    process.env.STYLE_GUIDE = "Brand Voice";
     expect(getActionConfig().apiToken).toBe("env-tok");
     expect(getActionConfig().target).toBe("Brand Voice");
   });
@@ -129,7 +129,7 @@ describe("getActionConfig", () => {
     inputs({
       markup_ai_api_key: "input-tok",
       github_token: "input-gh",
-      target: "Input Target",
+      style_guide: "Input Target",
     });
     process.env.MARKUP_AI_API_KEY = "env-tok";
     expect(getActionConfig().apiToken).toBe("input-tok");
@@ -149,7 +149,7 @@ describe("getActionConfig", () => {
     inputs({
       markup_ai_api_key: "tok",
       github_token: "gh",
-      target: "Brand Voice",
+      style_guide: "Brand Voice",
       strict_mode: "true",
       add_commit_status: "false",
       add_review_comments: "false",

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -118,7 +118,7 @@ function applyDefaultInputs() {
         return "test-key";
       case "github_token":
         return "gh-tok";
-      case "target":
+      case "style_guide":
         return "Marketing Voice";
       default:
         return "";
@@ -154,7 +154,7 @@ describe("Integration", () => {
 
   it("fails when the API key input is missing", async () => {
     core.getInput.mockImplementation(
-      mockInput({ markup_ai_api_key: "", target: "Marketing Voice", github_token: "gh-tok" }),
+      mockInput({ markup_ai_api_key: "", style_guide: "Marketing Voice", github_token: "gh-tok" }),
     );
     await run();
     expect(core.setFailed).toHaveBeenCalledWith(
@@ -162,9 +162,9 @@ describe("Integration", () => {
     );
   });
 
-  it("falls back to the org's default target when target input is omitted", async () => {
+  it("falls back to the org's default target when style_guide input is omitted", async () => {
     core.getInput.mockImplementation(
-      mockInput({ markup_ai_api_key: "k", target: "", github_token: "gh-tok" }),
+      mockInput({ markup_ai_api_key: "k", style_guide: "", github_token: "gh-tok" }),
     );
     await run();
     // Default target in the test fixture (`listStyleAgentTargets` mock) is

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -88,7 +88,7 @@ beforeEach(() => {
         return "test-key";
       case "github_token":
         return "gh-tok";
-      case "target":
+      case "style_guide":
         return "Marketing Voice";
       case "add_review_comments":
         return "false";
@@ -115,7 +115,7 @@ describe("main.ts", () => {
   it("fails when API token is missing", async () => {
     const inputs: Record<string, string> = {
       markup_ai_api_key: "",
-      target: "Marketing Voice",
+      style_guide: "Marketing Voice",
       github_token: "gh-tok",
     };
     core.getInput.mockImplementation((name: string) => inputs[name] ?? "");


### PR DESCRIPTION
## What

Renames the action's single public style input from **`target`** to **`style_guide`** so it matches our marketing terminology. The platform API still expects a `target_id`, so the value is mapped to the agent's `target` internally — **no behavioral change**, everything downstream works as before.

## Why

`style_guide` is the term we use everywhere in our marketing and console UI; `target` was a leaky internal/API name. This aligns the public surface with what users already know.

## Changes

- **`action.yml`** — input `target` → `style_guide` (still optional; omit to use the org default).
- **`src/constants/index.ts`** — `INPUT_NAMES.STYLE_GUIDE = "style_guide"`.
- **`src/config/action-config.ts`** — reads `style_guide` (env fallback `STYLE_GUIDE`) and maps it onto `config.target`. The internal `config.target` / `target_id` / `target-resolver` naming is intentionally unchanged.
- **Docs** — `README.md`, `CLAUDE.md`, `.env.example` (`INPUT_TARGET` → `INPUT_STYLE_GUIDE`).
- **Tests** — updated input-name mocks in `config`, `integration`, `main`, and `action-runner` tests.
- **`dist/`** — rebuilt via `npm run bundle`.

## Compatibility

⚠️ Breaking for any workflow that passes `target:` — they must rename it to `style_guide:`. Workflows relying on the org default need no change.

## Verification

- `npm run lint:check` ✅
- `npm test` → 265 passed, 1 skipped ✅
- `npm run bundle` ✅ (dist committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)