### PR TITLE
[INT-554] Spell out issue severity counts (High/Medium/Low)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -88385,7 +88385,7 @@ function generateFileDisplayLink(filePath, context) {
         : `[${filePath}](${context.baseUrl.origin}/${context.owner}/${context.repo}/blob/${context.ref}/${filePath})`;
 }
 function formatCounts(counts) {
-    return `H:${counts.high.toString()} M:${counts.medium.toString()} L:${counts.low.toString()}`;
+    return `High: ${counts.high.toString()}, Medium: ${counts.medium.toString()}, Low: ${counts.low.toString()}`;
 }
 function generateResultsTable(results, options, context) {
     if (results.length === 0) {
@@ -89104,7 +89104,7 @@ function riskToState(level) {
     return "success";
 }
 function formatCountsShort(counts) {
-    return `H:${counts.high.toString()} M:${counts.medium.toString()} L:${counts.low.toString()}`;
+    return `High: ${counts.high.toString()}, Medium: ${counts.medium.toString()}, Low: ${counts.low.toString()}`;
 }
 /**
  * Update the commit status. In numeric mode the description leads with the
@@ -89211,7 +89211,7 @@ function logNumericScores(result) {
 }
 function logIssueCounts(result) {
     const { total, high, medium, low } = result.issueCounts;
-    info(`⚠️  Issues: ${total.toString()} (H:${high.toString()} M:${medium.toString()} L:${low.toString()})`);
+    info(`⚠️  Issues: ${total.toString()} (High: ${high.toString()}, Medium: ${medium.toString()}, Low: ${low.toString()})`);
 }
 function displaySingleResult(result, options) {
     info(`\n📄 File: ${result.filePath}`);

--- a/src/services/github-service.ts
+++ b/src/services/github-service.ts
@@ -125,7 +125,7 @@ function riskToState(level: ReturnType<typeof aggregateRisk>): "success" | "fail
 }
 
 function formatCountsShort(counts: IssueCounts): string {
-  return `H:${counts.high.toString()} M:${counts.medium.toString()} L:${counts.low.toString()}`;
+  return `High: ${counts.high.toString()}, Medium: ${counts.medium.toString()}, Low: ${counts.low.toString()}`;
 }
 
 /**

--- a/src/utils/display-utils.ts
+++ b/src/utils/display-utils.ts
@@ -36,7 +36,7 @@ function logNumericScores(result: AnalysisResult): void {
 function logIssueCounts(result: AnalysisResult): void {
   const { total, high, medium, low } = result.issueCounts;
   core.info(
-    `⚠️  Issues: ${total.toString()} (H:${high.toString()} M:${medium.toString()} L:${low.toString()})`,
+    `⚠️  Issues: ${total.toString()} (High: ${high.toString()}, Medium: ${medium.toString()}, Low: ${low.toString()})`,
   );
 }
 

--- a/src/utils/markdown-utils.ts
+++ b/src/utils/markdown-utils.ts
@@ -44,7 +44,7 @@ function generateFileDisplayLink(filePath: string, context: RepositoryContext): 
 }
 
 function formatCounts(counts: IssueCounts): string {
-  return `H:${counts.high.toString()} M:${counts.medium.toString()} L:${counts.low.toString()}`;
+  return `High: ${counts.high.toString()}, Medium: ${counts.medium.toString()}, Low: ${counts.low.toString()}`;
 }
 
 export function generateResultsTable(


### PR DESCRIPTION
## Summary
- Per a PM request, severity-count breakdowns now spell out **High / Medium / Low** instead of the abbreviations **H / M / L**, for better readability.
- Applied consistently across every surface that rendered the breakdown: PR comments, job summaries, the push commit-status, and console logs.
- Format is now `High: N, Medium: N, Low: N`.

## JIRA
https://markup-ai.atlassian.net/browse/INT-554

## Changes
- `src/utils/markdown-utils.ts` (`formatCounts`) — PR comment tables + job summary "Total Issues" line.
- `src/services/github-service.ts` (`formatCountsShort`) — push commit-status description.
- `src/utils/display-utils.ts` (`logIssueCounts`) — action console logs (updated for consistency).
- `dist/index.js` + `dist/index.js.map` — regenerated via `npm run bundle` (action runs from `dist/`).

## GitHub length limit
The only length-constrained surface is the commit-status description, which GitHub caps at **140 characters**. With full words a realistic worst case (e.g. `Risk High | Quality 70 | Files 12 | Issues 45 (High: 5, Medium: 3, Low: 2)`) is ~84 characters, so there is no truncation risk. PR comments and job summaries are plain markdown with no meaningful limit.

## Test plan
- `npm test` — 265 passed, 1 skipped. No test asserted on the `H:/M:/L:` substring, and the `Risk`/`Quality` assertions (which use full-word labels already) still pass.
- `npm run bundle` — `dist/` regenerated and committed so `check-dist` stays green.